### PR TITLE
bugfix: allow packet-attack to load

### DIFF
--- a/csfieldguide/static/interactives/packet-attack/js/packet-attack.js
+++ b/csfieldguide/static/interactives/packet-attack/js/packet-attack.js
@@ -35,7 +35,11 @@ function run() {
         height: 600,
         backgroundColor: '#AAAAAA',
         parent: 'interactive-packet-attack',
-        scene: gameScene
+        scene: gameScene,
+        audio: {
+            noAudio: true
+        },
+
     }
 
     var skip = urlParameters.getUrlParameter('start');


### PR DESCRIPTION
Resolves #3086

## Proposed changes

Packet attack currently does not load due to a WebAudoSoundManager error. It it possible this is being created by phaser and being blocked by the browser potentially for audio policy reasons. 

As packet-attack uses no audio, audio can be turned off in the config and no further diagnosis is required, sidestepping the issue. No other interactives use phaser. 

### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the contribution guidelines.
- [x] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] I have added necessary documentation (if appropriate).
- [x] If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`
